### PR TITLE
GCCloud setup added to cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,9 +11,25 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.23.0'
+
       - name: build
         run: scripts/buildprod.sh
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Use gcloud CLI'
+        run: 'gcloud info'
+
+      - name: "Build and Push image to Gcloud Artifact Registry"
+        run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-439520/notely-ar-repo/notely:latest .


### PR DESCRIPTION
Established a service account on GCP, saved the JSON key as a repo secret, and use it to authenticate the setup process. Proceeds to build and push a docker image to our artifact registry.